### PR TITLE
Rbenv default gems

### DIFF
--- a/Manifest.mac
+++ b/Manifest.mac
@@ -9,11 +9,11 @@ mac-components/homebrew
 mac-components/nebulab-packages
 mac-components/nebulab-start-services
 mac-components/rbenv
+common-components/default-gems
 mac-components/node
 mac-components/compiler-and-libraries
 common-components/ruby-environment
 mac-components/bundler
-common-components/nebulab-default-gems
 mac-components/heroku
 mac-components/github
 mac-components/rcm

--- a/common-components/default-gems
+++ b/common-components/default-gems
@@ -1,2 +1,7 @@
-fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
-  gem install suspenders --no-document
+fancy_echo "Creating ~/.rbenv/default-gems, to automatically install default gems every time you install a new version of ruby ..."
+  touch ~/.rbenv/default-gems
+  for gem in bundler pulsar; do
+    if ! grep -Fxq "$gem" ~/.rbenv/default-gems; then
+      echo "$gem" >> ~/.rbenv/default-gems
+    fi
+  done

--- a/common-components/nebulab-default-gems
+++ b/common-components/nebulab-default-gems
@@ -1,2 +1,0 @@
-fancy_echo "Installing Pulsar, a tool to deploy with Capistrano ..."
-  gem install pulsar --no-document

--- a/common-components/ruby-environment
+++ b/common-components/ruby-environment
@@ -11,6 +11,3 @@ fancy_echo "Setting $RUBY_VERSION as global default Ruby ..."
 
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
-
-fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
-  gem install bundler --no-document --pre

--- a/linux
+++ b/linux
@@ -146,9 +146,6 @@ fancy_echo "Setting $RUBY_VERSION as global default Ruby ..."
 
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
-
-fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
-  gem install bundler --no-document --pre
 ### end common-components/ruby-environment
 
 fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
@@ -156,8 +153,13 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   bundle config --global jobs $((number_of_cores - 1))
 ### end linux-components/bundler
 
-fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
-  gem install suspenders --no-document
+fancy_echo "Creating ~/.rbenv/default-gems, to automatically install default gems every time you install a new version of ruby ..."
+  touch ~/.rbenv/default-gems
+  for gem in bundler pulsar; do
+    if ! grep -Fxq "$gem" ~/.rbenv/default-gems; then
+      echo "$gem" >> ~/.rbenv/default-gems
+    fi
+  done
 ### end common-components/default-gems
 
 fancy_echo "Installing Heroku CLI client ..."

--- a/mac
+++ b/mac
@@ -126,7 +126,19 @@ fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up bina
 
 fancy_echo "Installing ruby-build, to install Rubies ..."
   brew install ruby-build
+
+fancy_echo "Installing rbenv-default-gems, to automatically install gems every time you install a new version of ruby ..."
+  brew install rbenv-default-gems
 ### end mac-components/rbenv
+
+fancy_echo "Creating ~/.rbenv/default-gems, to automatically install default gems every time you install a new version of ruby ..."
+  touch ~/.rbenv/default-gems
+  for gem in bundler pulsar; do
+    if ! grep -Fxq "$gem" ~/.rbenv/default-gems; then
+      echo "$gem" >> ~/.rbenv/default-gems
+    fi
+  done
+### end common-components/default-gems
 
 fancy_echo "Installing Node.js ..."
   brew install nodejs
@@ -155,19 +167,12 @@ fancy_echo "Setting $RUBY_VERSION as global default Ruby ..."
 
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
-
-fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
-  gem install bundler --no-document --pre
 ### end common-components/ruby-environment
 
 fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
 ### end mac-components/bundler
-
-fancy_echo "Installing Pulsar, a tool to deploy with Capistrano ..."
-  gem install pulsar --no-document
-### end common-components/nebulab-default-gems
 
 fancy_echo "Installing Heroku CLI client ..."
   brew install heroku-toolbelt

--- a/mac-components/rbenv
+++ b/mac-components/rbenv
@@ -16,3 +16,6 @@ fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up bina
 
 fancy_echo "Installing ruby-build, to install Rubies ..."
   brew install ruby-build
+
+fancy_echo "Installing rbenv-default-gems, to automatically install gems every time you install a new version of ruby ..."
+  brew install rbenv-default-gems


### PR DESCRIPTION
@mtylty @kennyadsl: This pull request add https://github.com/sstephenson/rbenv-default-gems and some changes to make it work. Now we have a single file where we can put all our default gems https://github.com/nebulab/laptop/commit/6720018a8d5bbcac8cb4303a233d807a68572ff6 and thanks to rbenv-default-gems every time we install a new ruby version we have the default gems for free. The bad side is that it's don't work with already installed ruby.
